### PR TITLE
Add support for ARM64 architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-14 # aarch64
+          - macos-13 # x86_64
           - ubuntu-latest
 
     runs-on: ${{ matrix.os }}

--- a/bin/install
+++ b/bin/install
@@ -11,6 +11,20 @@ readonly TMP_DOWNLOAD_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
 
 #
+_get_arch() {
+  local arch; arch=$(uname -m)
+  case $arch in
+    armv*) arch="arm";;
+    aarch64 | arm64) arch="arm64";;
+    x86_64) arch="amd64";;
+  esac
+  echo "$arch"
+}
+
+_get_platform() {
+	uname | tr '[:upper:]' '[:lower:]'
+}
+
 error_exit() {
   echo "$1" >&2
   exit "${2:-1}"
@@ -21,8 +35,9 @@ install() {
   local -r install_version="$2"
   local -r install_path="$3"
   local -r install_path_bin="${install_path}/bin"
-  local -r platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
-  local -r download_url="${DOWNLOAD_BASE_URL}/v${install_version}/${BINARY_NAME}-${platform}"
+  local -r platform="$(_get_platform)"
+  local -r arch="$(_get_arch)"
+  local -r download_url="${DOWNLOAD_BASE_URL}/v${install_version}/${BINARY_NAME}-${platform}-${arch}"
   local -r download_path="${TMP_DOWNLOAD_DIR}/${BINARY_NAME}"
 
   [ "$install_type" != "version" ] && error_exit "Error: source installs are not supported"


### PR DESCRIPTION
Hi! This pull request adds support for ARM64 builds of `jsonnet-bundler` that are available starting from v0.6.0. See the upstream release here https://github.com/jsonnet-bundler/jsonnet-bundler/releases/tag/v0.6.0

Here is an example of installing `jsonnet-bundler` on ARM64-based macOS. I used `mise` in tests but that should be fine since `mise` is `asdf`-compatible.

```plaintext
❯ mise install --verbose jb
[DEBUG] ARGS: /Users/vslobodin/.local/bin/mise install --verbose jb
[DEBUG] Config {
    Config Files: [
        "~/.config/mise/config.toml",
    ],
}
[DEBUG] ToolRequestSet.build(116.208µs): ToolRequestSet: chezmoi@2 go@latest java@lts kubectl@latest node@lts python@latest ruby@3.3.4 usage@latest cargo:cargo-audit@latest cargo:cargo-binstall@latest cargo:cargo-cache@latest cargo:cargo-generate@latest cargo:cargo-edit@latest cargo:cargo-info@latest cargo:cargo-update@latest cargo:sccache@latest cargo:tokei@latest cargo:topgrade@latest cargo:just@latest go:github.com/DarthSim/hivemind@latest npm:@devcontainers/cli@latest npm:neovim@latest npm:pnpm@latest npm:yarn@latest cargo:jj-cli@latest

[DEBUG] install_versions: jb@latest
installing
~/.local/share/mise/plugins/jb/bin/install
[DEBUG] $ ~/.local/share/mise/plugins/jb/bin/install
Downloading from https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v0.6.0/jb-darwin-arm64
``` 

And running the `jb`:

```plaintext
❯ mise exec jb -- jb --version
v0.6.0
```

I also updated the GitHub actions file by adding a new entry `macos-13` under the `matrix` key to ensure CI runs for both `x86_64` and `arm64` versions of macOS. Thanks!